### PR TITLE
[Possible Fatal] Check if directory exists?

### DIFF
--- a/pacmerge
+++ b/pacmerge
@@ -1,6 +1,14 @@
 #!/bin/sh
 
-cd ~/.cache/pacmerge
+CACHE_DIR="$HOME/.cache/pacmerge/"
+
+mkcdir() {
+	if [[ $# -eq 1 ]]; then
+		mkdir "$1" && cd "$1"
+	fi
+}
+
+[ -e "$CACHE_DIR" ] && cd ~/.cache/pacmerge || mkcdir "$CACHE_DIR"
 asp checkout $1
 cd $1/repos/*
 makepkg -si

--- a/pacmerge
+++ b/pacmerge
@@ -4,7 +4,7 @@ CACHE_DIR="$HOME/.cache/pacmerge/"
 
 mkcdir() {
 	if [[ $# -eq 1 ]]; then
-		mkdir "$1" && cd "$1"
+		mkdir -p "$1" && cd "$1"
 	fi
 }
 


### PR DESCRIPTION
This is a potential issue if the `~/.cache/pacmerge/` directory does not exist, which will lead the script to fail. I suppose it's better to check if the directory exist or not...